### PR TITLE
pytest-datadir 1.6.1 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<38]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,31 +10,41 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<38]
 
 requirements:
   host:
     - pip
-    - python >=3.6
-    - setuptools_scm
+    - python
+    - wheel
+    - setuptools >=61
+    - setuptools_scm >=6.2
   run:
-    - python >=3.6
-    - pytest
+    - python
+    - pytest >=7.0
 
 test:
-  requires:
-    - pytest
+  source_files:
+    - tests
   imports:
     - pytest_datadir
   commands:
-    - pytest --help
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests
+  requires:
+    - pip
 
 about:
   home: https://github.com/gabrielcnr/pytest-datadir
-  license: MIT
-  license_file: LICENSE
   summary: pytest plugin for manipulating test data directories and files.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  description: pytest plugin for manipulating test data directories and files.
+  doc_url: https://github.com/gabrielcnr/pytest-datadir/blob/master/README.md
+  dev_url: https://github.com/gabrielcnr/pytest-datadir
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
pytest-datadir 1.6.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8233]
- dev_url:        https://github.com/gabrielcnr/pytest-datadir/tree/v1.6.1
- conda_forge:    https://github.com/conda-forge/pytest-datadir-feedstock
- pypi:           https://pypi.org/project/pytest-datadir/1.6.1
- pypi inspector: https://inspector.pypi.io/project/pytest-datadir/1.6.1

### Explanation of changes:

- new version number


[PKG-8233]: https://anaconda.atlassian.net/browse/PKG-8233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ